### PR TITLE
Update Maven plugins, dependencies and improve code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Converts GML to JTS. For now GML 3.1.1.2 and 3.2.1 are supported.
 <dependency>
   <groupId>nl.pdok</groupId>
   <artifactId>gml3-jts</artifactId>
-  <version>17.0.0</version>
+  <version>17.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>nl.pdok</groupId>
   <artifactId>gml3-jts</artifactId>
-  <version>17.0.0</version>
+  <version>17.1.0</version>
   <name>${project.artifactId}</name>
   <description>Conversion library from gml3 to JTS objects</description>
   <url>https://github.com/PDOK/gml3-jts</url>
@@ -27,8 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 
   <scm>
@@ -57,7 +56,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.12</version>
+          <version>1.6.13</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>
@@ -68,7 +67,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>sign-artifacts</id>
@@ -82,35 +81,64 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.jaxb2.maven2</groupId>
           <artifactId>maven-jaxb2-plugin</artifactId>
-          <version>0.12.3</version>
+          <version>0.15.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.5</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.6</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -141,7 +169,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <remoteTagging>true</remoteTagging>
           <preparationGoals>clean</preparationGoals>
@@ -164,24 +191,19 @@
       <version>2.6.1</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>3.0.2</version>
+      <version>2.3.9</version>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>4.0.0</version>
+      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
@@ -191,17 +213,17 @@
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.18.2</version>
+      <version>1.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.xsd</groupId>
       <artifactId>gt-xsd-gml3</artifactId>
-      <version>26.4</version>
+      <version>29.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -211,12 +233,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.13</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.13</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -227,7 +249,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.15.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/nl/pdok/gml3/impl/geometry/extended/ArcLineString.java
+++ b/src/main/java/nl/pdok/gml3/impl/geometry/extended/ArcLineString.java
@@ -1,5 +1,6 @@
 package nl.pdok.gml3.impl.geometry.extended;
 
+import java.io.Serial;
 import org.locationtech.jts.algorithm.Length;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
@@ -14,6 +15,7 @@ import org.locationtech.jts.geom.impl.CoordinateArraySequence;
  */
 public class ArcLineString extends LineString {
 
+	@Serial
 	private static final long serialVersionUID = 5858160826964840982L;
 	private CoordinateSequence densifiedPoints = null;
 	private static final int NUMBER_OF_ORDINATES = 3;
@@ -27,7 +29,7 @@ public class ArcLineString extends LineString {
 	public ArcLineString(CoordinateSequence points, GeometryFactory factory) {
 		super(points, factory);
 	}
-	
+
 	/**
 	 * Get the real non-densified points (densification is used to create
 	 *
@@ -46,7 +48,7 @@ public class ArcLineString extends LineString {
 	/** {@inheritDoc} */
 	@Override
 	public LineString reverse() {
-		CoordinateSequence seq = (CoordinateSequence) points.copy();
+		CoordinateSequence seq = points.copy();
 		CoordinateSequences.reverse(seq);
 		return getFactory().createLineString(seq);
 	}
@@ -82,12 +84,13 @@ public class ArcLineString extends LineString {
 	 *
 	 * @return a {@link java.lang.Object} object.
 	 */
+	@Override
 	public Object clone() {
 		ArcLineString arc = (ArcLineString) super.copy();
-		arc.points = (CoordinateSequence) points.copy();
+		arc.points = points.copy();
 		return arc;
 	}
-	
+
 	/**
 	 * Used instead of the call to points, so JTS thinks the arc is just a LineString with a lot of
 	 * points.
@@ -98,7 +101,7 @@ public class ArcLineString extends LineString {
 		if(densifiedPoints == null) {
 			Coordinate[] points = getArcCoordinates();
 			Coordinate[] result = null;
-			
+
 			for(int i=0;i+NUMBER_OF_ORDINATES<=points.length;i=i+2) {
 				Coordinate[] arcItem = new Coordinate[NUMBER_OF_ORDINATES];
 				System.arraycopy(points, i, arcItem, 0, NUMBER_OF_ORDINATES);
@@ -108,7 +111,7 @@ public class ArcLineString extends LineString {
 
 			densifiedPoints = new CoordinateArraySequence(result);
 		}
-		
+
 		return densifiedPoints;
 	}
 
@@ -135,7 +138,7 @@ public class ArcLineString extends LineString {
 	public Point getPointN(int n) {
 		return getFactory().createPoint(getDensifiedPoints().getCoordinate(n));
 	}
-	
+
 	/** {@inheritDoc} */
 	@Override
 	public int getNumPoints() {
@@ -182,7 +185,7 @@ public class ArcLineString extends LineString {
 		if (getDensifiedPoints().size() == 0) {
 			return;
 		}
-		
+
 		for (int i = 0; i < getDensifiedPoints().size(); i++) {
 			filter.filter(getDensifiedPoints(), i);
 			if (filter.isDone()){
@@ -193,7 +196,7 @@ public class ArcLineString extends LineString {
 			geometryChanged();
 		}
 	}
-	
+
 	/** {@inheritDoc} */
 	@Override
 	public void normalize() {

--- a/src/main/java/nl/pdok/gml3/impl/geometry/extended/Ring.java
+++ b/src/main/java/nl/pdok/gml3/impl/geometry/extended/Ring.java
@@ -1,5 +1,6 @@
 package nl.pdok.gml3.impl.geometry.extended;
 
+import java.io.Serial;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 
@@ -19,8 +20,9 @@ import java.util.Set;
  */
 public class Ring extends LinearRing {
 
+	@Serial
 	private static final long serialVersionUID = 7685049284222295173L;
-	private CompoundLineString compoundLineString;
+	private final CompoundLineString compoundLineString;
 
 	/**
 	 * <p>Constructor for Ring.</p>
@@ -39,6 +41,7 @@ public class Ring extends LinearRing {
 	 *
 	 * @return a {@link java.lang.String} object.
 	 */
+	@Override
 	public String getGeometryType() {
 		return "Ring";
 	}
@@ -48,10 +51,11 @@ public class Ring extends LinearRing {
 	 *
 	 * @return a {@link org.locationtech.jts.geom.Geometry} object.
 	 */
+	@Override
 	public LinearRing reverse() {
-		return createRing(factory, (CompoundLineString) compoundLineString.reverse());
+		return createRing(factory, compoundLineString.reverse());
 	}
-	
+
 	/**
 	 * <p>createRing.</p>
 	 *
@@ -62,7 +66,7 @@ public class Ring extends LinearRing {
 	public static Ring createRing(GeometryFactory factory, CompoundLineString compoundLineString) {
 		LineString[] segments = compoundLineString.getSegments();
 		return createRing(factory, segments);
-		
+
 	}
 
 	/**
@@ -84,7 +88,7 @@ public class Ring extends LinearRing {
 		CoordinateSequence coordinateSequence =
 			new CoordinateArraySequence(coordsWithoutDuplicates.toArray(new Coordinate[] {}));
 		return new Ring(coordinateSequence, factory, segments);
-		
+
 	}
 
 	/**
@@ -94,7 +98,7 @@ public class Ring extends LinearRing {
 	 */
 	public LineString[] getSegments() {
 		return compoundLineString.getSegments();
-		
+
 	}
 
 }

--- a/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/GML3112ParserImpl.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/GML3112ParserImpl.java
@@ -40,16 +40,16 @@ public class GML3112ParserImpl implements GMLParser {
         try {
             GML_3112_JAXB_CONTEXT = JAXBContext.newInstance(AbstractGeometryType.class);
             LOGGER.debug("Created JAXB context");
-            GML_3112_UNMARSHALLER = new ThreadLocal<Unmarshaller>() {
-                @Override
-                protected Unmarshaller initialValue() {
-                    try {
-                        return GML_3112_JAXB_CONTEXT.createUnmarshaller();
-                    } catch (JAXBException ex) {
-                        LOGGER.error(ex.getMessage(), ex);
-                        throw new IllegalStateException(ex);
-                    }
+            GML_3112_UNMARSHALLER = new ThreadLocal<>() {
+              @Override
+              protected Unmarshaller initialValue() {
+                try {
+                  return GML_3112_JAXB_CONTEXT.createUnmarshaller();
+                } catch (JAXBException ex) {
+                  LOGGER.error(ex.getMessage(), ex);
+                  throw new IllegalStateException(ex);
                 }
+              }
             };
         } catch (JAXBException ex) {
             LOGGER.error("Could not create JAXB context. {}", ex.getMessage(), ex);
@@ -70,7 +70,7 @@ public class GML3112ParserImpl implements GMLParser {
      * <p>Constructor for GML3112ParserImpl.</p>
      *
      * @param maximumArcApproximationError a double.
-     * @param srid a int.
+     * @param srid an int.
      */
     public GML3112ParserImpl(final double maximumArcApproximationError, final int srid) {
         ExtendedGeometryFactory geometryFactory = new ExtendedGeometryFactory(new PrecisionModel(), srid);
@@ -102,14 +102,14 @@ public class GML3112ParserImpl implements GMLParser {
     @Override
     public Geometry toJTSGeometry(String gml) throws GML3ParseException {
         if (StringUtils.isBlank(gml)) {
-            throw new GML3ParseException("Emtpy GML-string provided");
+            throw new GML3ParseException("Empty GML-string provided");
         }
         return toJTSGeometry(new StringReader(gml));
     }
 
     private AbstractGeometryType parseGeometryFromGML(Reader reader) throws JAXBException {
         JAXBElement<AbstractGeometryType> unmarshalled = (JAXBElement<AbstractGeometryType>) GML_3112_UNMARSHALLER.get().unmarshal(new StreamSource(reader));
-        return (AbstractGeometryType) unmarshalled.getValue();
+        return unmarshalled.getValue();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToJTSGeometryConvertor.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToJTSGeometryConvertor.java
@@ -37,18 +37,18 @@ public class GMLToJTSGeometryConvertor {
      * @throws nl.pdok.gml3.exceptions.GeometryException if any.
      */
     public Geometry convertGeometry(AbstractGeometryType abstractGeometryType) throws GeometryException {
-        if (abstractGeometryType instanceof AbstractSurfaceType) {
-            return gmlToSurfaceConvertor.convertSurface((AbstractSurfaceType) abstractGeometryType);
+        if (abstractGeometryType instanceof AbstractSurfaceType abstractSurfaceType) {
+            return gmlToSurfaceConvertor.convertSurface(abstractSurfaceType);
 
-        } else if (abstractGeometryType instanceof MultiPointType) {
-            return gmlToPointConvertor.convertMultiPoint((MultiPointType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof PointType) {
-            return gmlToPointConvertor.convertPoint((PointType) abstractGeometryType);
+        } else if (abstractGeometryType instanceof MultiPointType multiPointType) {
+            return gmlToPointConvertor.convertMultiPoint(multiPointType);
+        } else if (abstractGeometryType instanceof PointType pointType) {
+            return gmlToPointConvertor.convertPoint(pointType);
 
-        } else if (abstractGeometryType instanceof AbstractCurveType) {
-            return gmlToLineConvertor.convertAbstractCurve((AbstractCurveType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof MultiSurfaceType) {
-            return gmlToSurfaceConvertor.convertMultiSurface((MultiSurfaceType) abstractGeometryType);
+        } else if (abstractGeometryType instanceof AbstractCurveType abstractCurveType) {
+            return gmlToLineConvertor.convertAbstractCurve(abstractCurveType);
+        } else if (abstractGeometryType instanceof MultiSurfaceType multiSurfaceType) {
+            return gmlToSurfaceConvertor.convertMultiSurface(multiSurfaceType);
         } else {
             throw new IllegalArgumentException("Geometry type not supported: "
                     + abstractGeometryType.getClass());

--- a/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToPointConvertor.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToPointConvertor.java
@@ -25,7 +25,7 @@ import nl.pdok.gml3.exceptions.InvalidGeometryException;
  */
 public class GMLToPointConvertor {
 
-	private GeometryFactory geometryFactory;
+	private final GeometryFactory geometryFactory;
 
 	/**
 	 * <p>Constructor for GMLToPointConvertor.</p>
@@ -50,7 +50,7 @@ public class GMLToPointConvertor {
 		if (coordinates == null || coordinates.size() < dimension) {
 			throw new InvalidGeometryException(GeometryValidationErrorType.EMPTY_GEOMETRY, null);
 		}
-		
+
 		if(coordinates.size()%dimension != 0) {
 			throw new InvalidGeometryException(GeometryValidationErrorType.INVALID_COORDINATE, null);
 		}
@@ -58,13 +58,13 @@ public class GMLToPointConvertor {
 		CoordinateArraySequence sequence = new CoordinateArraySequence(coordinates.size() / dimension);
 		int i = 0;
 		for (Double ordinate : coordinates) {
-			BigDecimal bd = new BigDecimal(ordinate);
+			BigDecimal bd = BigDecimal.valueOf(ordinate);
 			int ordinateIndex = i % dimension;
 			int index = (i / dimension);
 			sequence.setOrdinate(index, ordinateIndex, bd.doubleValue());
 			i++;
 		}
-		
+
 		return sequence;
 
 	}
@@ -93,7 +93,7 @@ public class GMLToPointConvertor {
 		if(values.size() != dimension) {
 			throw new InvalidGeometryException(GeometryValidationErrorType.POINT_INVALID_NUMBER_OF_ORDINATES, null);
 		}
-		
+
 		CoordinateArraySequence sequence = translateOrdinates(values, dimension);
 		return geometryFactory.createPoint(sequence);
 	}
@@ -114,15 +114,15 @@ public class GMLToPointConvertor {
 				points.add(convertPoint(point));
 			}
 		}
-		
+
 		for(PointPropertyType type : multipointType.getPointMember()) {
 			PointType pointType = type.getPoint();
 			if(pointType != null) {
 				points.add(convertPoint(pointType));
 			}
 		}
-		
-		if(points.size() < 1) {
+
+		if(points.isEmpty()) {
 			throw new InvalidGeometryException(GeometryValidationErrorType.MULTI_POINT_DID_NOT_CONTAIN_MEMBERS, null);
 		}
 		else if(points.size() == 1) {

--- a/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToSurfaceConvertor.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/convertors/GMLToSurfaceConvertor.java
@@ -26,8 +26,8 @@ import nl.pdok.gml3.exceptions.UnsupportedGeometrySpecificationException;
  */
 public class GMLToSurfaceConvertor {
 
-		private GeometryFactory geometryFactory;
-		private GMLToLineConvertor gmlToLineConvertor;
+		private final GeometryFactory geometryFactory;
+		private final GMLToLineConvertor gmlToLineConvertor;
 
 		/**
 		 * <p>Constructor for GMLToSurfaceConvertor.</p>
@@ -35,12 +35,12 @@ public class GMLToSurfaceConvertor {
 		 * @param geometryFactory a {@link org.locationtech.jts.geom.GeometryFactory} object.
 		 * @param gmlToLineConvertor a {@link nl.pdok.gml3.impl.gml3_1_1_2.convertors.GMLToLineConvertor} object.
 		 */
-		public GMLToSurfaceConvertor(GeometryFactory geometryFactory, GMLToLineConvertor 
+		public GMLToSurfaceConvertor(GeometryFactory geometryFactory, GMLToLineConvertor
 				gmlToLineConvertor) {
 			this.geometryFactory = geometryFactory;
 			this.gmlToLineConvertor = gmlToLineConvertor;
 		}
-		
+
 		/**
 		 * <p>convertMultiSurface.</p>
 		 *
@@ -55,7 +55,7 @@ public class GMLToSurfaceConvertor {
 				Geometry result = convertElementContainingSurface(element);
 				addResultingPolygonsToList(result, polygons);
 			}
-			
+
 			SurfaceArrayPropertyType array = surfaces.getSurfaceMembers();
 			if(array != null) {
 				List<JAXBElement<? extends AbstractSurfaceType>> arraySurfaceMembers = array.getSurface();
@@ -66,26 +66,26 @@ public class GMLToSurfaceConvertor {
 					}
 				}
 			}
-			
+
 			return convertPolygonListToMuliPolygonOrSinglePolygon(polygons);
 		}
-		
+
 		private Geometry convertPolygonListToMuliPolygonOrSinglePolygon(List<Polygon> polygons)
 				throws GeometryException {
-			if(polygons.size() < 1) {
+			if(polygons.isEmpty()) {
 				throw new InvalidGeometryException(
 						GeometryValidationErrorType.MULTI_SURFACE_DID_NOT_CONTAIN_MEMBERS, null);
 			}
 			else if (polygons.size() == 1) {
 				return polygons.get(0);
-			} 
+			}
 			else {
 				MultiPolygon multi = new MultiPolygon(
 						polygons.toArray(new Polygon[] {}), geometryFactory);
 				return multi;
 			}
 		}
-		
+
 		private Geometry convertElementContainingSurface(
 				JAXBElement<? extends AbstractSurfaceType> surface) throws GeometryException {
 			if(surface != null) {
@@ -94,14 +94,13 @@ public class GMLToSurfaceConvertor {
 					return convertSurface(abstractSurfaceType);
 				}
 			}
-			
+
 			return null;
 		}
-		
+
 		private void addResultingPolygonsToList(Geometry geometry, List<Polygon> polygons) {
 			if(geometry != null) {
-				if(geometry instanceof MultiPolygon) {
-					MultiPolygon collection = (MultiPolygon) geometry;
+				if(geometry instanceof MultiPolygon collection) {
 					for(int i=0; i<collection.getNumGeometries(); i++) {
 						polygons.add((Polygon)collection.getGeometryN(i));
 					}
@@ -111,7 +110,7 @@ public class GMLToSurfaceConvertor {
 				}
 			}
 		}
-		
+
 
 		/**
 		 * <p>convertSurface.</p>
@@ -122,16 +121,14 @@ public class GMLToSurfaceConvertor {
 		 */
 		public Geometry convertSurface(AbstractSurfaceType abstractSurface)
 				throws GeometryException {
-			if (abstractSurface instanceof SurfaceType) {
-				List<Polygon> polygons = new ArrayList<Polygon>();
-				SurfaceType surface = (SurfaceType) abstractSurface;
+			if (abstractSurface instanceof SurfaceType surface) {
+				List<Polygon> polygons = new ArrayList<>();
 				SurfacePatchArrayPropertyType patches = surface.getPatches().getValue();
 				// opmerking multipliciteit 2 of meer is afgevangen door xsd
 				for (int i = 0; i < patches.getSurfacePatch().size(); i++) {
 					AbstractSurfacePatchType abstractPatch = patches
 							.getSurfacePatch().get(i).getValue();
-					if (abstractPatch instanceof PolygonPatchType) {
-						PolygonPatchType polygonPatch = (PolygonPatchType) abstractPatch;
+					if (abstractPatch instanceof PolygonPatchType polygonPatch) {
 						Polygon polygon = convertPolygonPatch(polygonPatch);
 						polygons.add(polygon);
 
@@ -142,13 +139,12 @@ public class GMLToSurfaceConvertor {
 				}
 
 				return convertPolygonListToMuliPolygonOrSinglePolygon(polygons);
-			} 
-			else if (abstractSurface instanceof PolygonType) {
-				PolygonType polygonType = (PolygonType) abstractSurface;
+			}
+			else if (abstractSurface instanceof PolygonType polygonType) {
 				if(polygonType.getExterior() == null) {
 					throw new InvalidGeometryException(GeometryValidationErrorType.POLYGON_HAS_NO_EXTERIOR, null);
 				}
-				
+
 				AbstractRingPropertyType abstractRing = polygonType.getExterior().getValue();
 				LinearRing shell = gmlToLineConvertor.translateAbstractRing(abstractRing);
 				LinearRing[] innerRings = new LinearRing[polygonType.getInterior().size()];
@@ -179,7 +175,7 @@ public class GMLToSurfaceConvertor {
 			if(polygonPatch.getExterior() == null) {
 				throw new InvalidGeometryException(GeometryValidationErrorType.POLYGON_HAS_NO_EXTERIOR, null);
 			}
-			
+
 			AbstractRingPropertyType abstractRing = polygonPatch.getExterior().getValue();
 			LinearRing exteriorShell = gmlToLineConvertor.translateAbstractRing(abstractRing);
 			if (!Orientation.isCCW(exteriorShell.getCoordinates())) {

--- a/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321ParserImpl.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321ParserImpl.java
@@ -39,16 +39,16 @@ public class GML321ParserImpl implements GMLParser {
         try {
             GML_321_JAXB_CONTEXT = JAXBContext.newInstance(AbstractGeometryType.class);
             LOGGER.debug("Created JAXB context");
-            GML_321_UNMARSHALLER = new ThreadLocal<Unmarshaller>() {
-                @Override
-                protected Unmarshaller initialValue() {
-                    try {
-                        return GML_321_JAXB_CONTEXT.createUnmarshaller();
-                    } catch (JAXBException ex) {
-                        LOGGER.error(ex.getMessage(), ex);
-                        throw new IllegalStateException(ex);
-                    }
+            GML_321_UNMARSHALLER = new ThreadLocal<>() {
+              @Override
+              protected Unmarshaller initialValue() {
+                try {
+                  return GML_321_JAXB_CONTEXT.createUnmarshaller();
+                } catch (JAXBException ex) {
+                  LOGGER.error(ex.getMessage(), ex);
+                  throw new IllegalStateException(ex);
                 }
+              }
             };
         } catch (JAXBException ex) {
             LOGGER.error("Could not create JAXB context. {}", ex.getMessage(), ex);
@@ -108,7 +108,7 @@ public class GML321ParserImpl implements GMLParser {
 
     private AbstractGeometryType parseGeometryFromGML(Reader reader) throws JAXBException {
         JAXBElement<AbstractGeometryType> unmarshalled = (JAXBElement<AbstractGeometryType>) GML_321_UNMARSHALLER.get().unmarshal(new StreamSource(reader));
-        return (AbstractGeometryType) unmarshalled.getValue();
+        return unmarshalled.getValue();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/nl/pdok/gml3/impl/gml3_2_1/converters/GML321ToJTSGeometryConvertor.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_2_1/converters/GML321ToJTSGeometryConvertor.java
@@ -36,19 +36,19 @@ public class GML321ToJTSGeometryConvertor {
      * @throws nl.pdok.gml3.exceptions.GeometryException if any.
      */
     public Geometry convertGeometry(AbstractGeometryType abstractGeometryType) throws GeometryException {
-        if (abstractGeometryType instanceof AbstractSurfaceType) {
-            return gmlToSurfaceConvertor.convertSurface((AbstractSurfaceType) abstractGeometryType);
+        if (abstractGeometryType instanceof AbstractSurfaceType surfaceType) {
+            return gmlToSurfaceConvertor.convertSurface(surfaceType);
 
-        } else if (abstractGeometryType instanceof MultiPointType) {
-            return gmlToPointConvertor.convertMultiPoint((MultiPointType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof PointType) {
-            return gmlToPointConvertor.convertPoint((PointType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof AbstractCurveType) {
-            return gmlToLineConvertor.convertAbstractCurve((AbstractCurveType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof MultiSurfaceType) {
-            return gmlToSurfaceConvertor.convertMultiSurface((MultiSurfaceType) abstractGeometryType);
-        } else if (abstractGeometryType instanceof MultiCurveType) {
-            return gmlToLineConvertor.convertMultiCurve((MultiCurveType) abstractGeometryType);
+        } else if (abstractGeometryType instanceof MultiPointType multiPointType) {
+            return gmlToPointConvertor.convertMultiPoint(multiPointType);
+        } else if (abstractGeometryType instanceof PointType pointType) {
+            return gmlToPointConvertor.convertPoint(pointType);
+        } else if (abstractGeometryType instanceof AbstractCurveType curveType) {
+            return gmlToLineConvertor.convertAbstractCurve(curveType);
+        } else if (abstractGeometryType instanceof MultiSurfaceType multiSurfaceType) {
+            return gmlToSurfaceConvertor.convertMultiSurface(multiSurfaceType);
+        } else if (abstractGeometryType instanceof MultiCurveType multiCurveType) {
+            return gmlToLineConvertor.convertMultiCurve(multiCurveType);
         } else {
             throw new IllegalArgumentException("Geometry type not supported: "
                     + abstractGeometryType.getClass());


### PR DESCRIPTION
# Omschrijving

Hoofdreden voor de wijziging is dat er voor enkele van de _transitive dependencies_  (e.g. GeoTools) vulnerabilities zijn gerapporteerd.
In deze PR daarom version bumps en hier en daar wat code verbeteringen.

## Type verandering

- Minor change
  - GeoTools 29.x
  - maven plugins naar laatste versie
  - maven enforcer plugin introduceren
  - downgrade jakarta.xml.bind-api versie (moet nog degene zijn die javax package bevat)
- Refactor
  - `@Override` toevoegen
  - Gebruik van _pattern matching for instanceof_ & casts weg waar niet nodig
  - `final` indien mogelijk

# Checklist:

(niet relevante zaken heb ik ook aangevinkt)

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [x] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)