### PR TITLE
Remove ThreadLocal usage and bump dependencies + plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>nl.pdok</groupId>
   <artifactId>gml3-jts</artifactId>
-  <version>30.0.0</version>
+  <version>30.1.0</version>
   <name>${project.artifactId}</name>
   <description>Conversion library from gml3 to JTS objects</description>
   <url>https://github.com/PDOK/gml3-jts</url>
@@ -67,7 +67,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.2.8</version>
           <executions>
             <execution>
               <id>sign-artifacts</id>
@@ -81,7 +81,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -90,7 +90,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.6.0</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -105,8 +105,8 @@
             <failsOnError>true</failsOnError>
             <violationSeverity>warning</violationSeverity>
             <sourceDirectories>
-              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory> 
-              <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory> 
+              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+              <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
             </sourceDirectories>
             <suppressionsLocation>${maven.multiModuleProjectDirectory}/tooling/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
           </configuration>
@@ -123,7 +123,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.43.0</version>
+          <version>2.44.5</version>
           <configuration>
             <java>
               <eclipse>
@@ -133,7 +133,7 @@
               <endWithNewline/>
               <importOrder>
                 <file>${maven.multiModuleProjectDirectory}/tooling/spotless/pdok.importorder</file>
-              </importOrder>              
+              </importOrder>
               <trimTrailingWhitespace/>
               <indent>
                 <spaces>true</spaces>
@@ -150,14 +150,14 @@
               </goals>
             </execution>
           </executions>
-        </plugin>        
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.jvnet.jaxb</groupId>
         <artifactId>jaxb-maven-plugin</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.9</version>
         <executions>
           <execution>
             <id>gml</id>
@@ -185,19 +185,19 @@
           <dependency>
             <groupId>org.jvnet.jaxb</groupId>
             <artifactId>jaxb-plugins</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.9</version>
           </dependency>
           <dependency>
             <groupId>org.jvnet.jaxb</groupId>
             <artifactId>jaxb-plugin-annotate</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.9</version>
           </dependency>
         </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>add-source</id>
@@ -221,11 +221,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>      
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -258,7 +258,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.11.2</version>
         <configuration>
           <excludePackageNames>org.opengis.*:org.w3.*</excludePackageNames>
         </configuration>
@@ -274,7 +274,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.1</version>
         <configuration>
           <remoteTagging>true</remoteTagging>
           <preparationGoals>clean</preparationGoals>
@@ -296,27 +296,27 @@
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.19.0</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.xsd</groupId>
       <artifactId>gt-xsd-gml3</artifactId>
-      <version>30.2</version>
+      <version>33.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -328,7 +328,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.15.1</version>
+      <version>2.19.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/GML3112ParserImpl.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_1_1_2/GML3112ParserImpl.java
@@ -3,7 +3,6 @@ package nl.pdok.gml3.impl.gml3_1_1_2;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 import java.io.Reader;
 import java.io.StringReader;
 import javax.xml.transform.stream.StreamSource;
@@ -32,23 +31,11 @@ public class GML3112ParserImpl implements GMLParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GML3112ParserImpl.class);
   private static final JAXBContext GML_3112_JAXB_CONTEXT;
-  private static final ThreadLocal<Unmarshaller> GML_3112_UNMARSHALLER;
 
   static {
     try {
       GML_3112_JAXB_CONTEXT = JAXBContext.newInstance(AbstractGeometryType.class);
       LOGGER.debug("Created JAXB context");
-      GML_3112_UNMARSHALLER = new ThreadLocal<>() {
-        @Override
-        protected Unmarshaller initialValue() {
-          try {
-            return GML_3112_JAXB_CONTEXT.createUnmarshaller();
-          } catch (JAXBException ex) {
-            LOGGER.error(ex.getMessage(), ex);
-            throw new IllegalStateException(ex);
-          }
-        }
-      };
     } catch (JAXBException ex) {
       LOGGER.error("Could not create JAXB context. {}", ex.getMessage(), ex);
       throw new IllegalStateException("Could not create JAXB context", ex);
@@ -115,7 +102,7 @@ public class GML3112ParserImpl implements GMLParser {
 
   private AbstractGeometryType parseGeometryFromGML(Reader reader) throws JAXBException {
     JAXBElement<AbstractGeometryType> unmarshalled =
-        (JAXBElement<AbstractGeometryType>) GML_3112_UNMARSHALLER.get()
+        (JAXBElement<AbstractGeometryType>) GML_3112_JAXB_CONTEXT.createUnmarshaller()
             .unmarshal(new StreamSource(reader));
     return unmarshalled.getValue();
   }

--- a/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321GeotoolsParserImpl.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321GeotoolsParserImpl.java
@@ -3,6 +3,7 @@ package nl.pdok.gml3.impl.gml3_2_1;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.function.Supplier;
 import javax.xml.parsers.ParserConfigurationException;
 import nl.pdok.gml3.GMLParser;
 import nl.pdok.gml3.exceptions.GML3ParseException;
@@ -24,7 +25,7 @@ import org.xml.sax.SAXException;
 public class GML321GeotoolsParserImpl implements GMLParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GML321GeotoolsParserImpl.class);
-  private final ThreadLocal<Parser> PARSER_THREAD_LOCAL;
+  private final Supplier<Parser> parserSupplier;
 
   /**
    * <p>
@@ -41,14 +42,13 @@ public class GML321GeotoolsParserImpl implements GMLParser {
    * Constructor for GML321GeotoolsParserImpl.
    * </p>
    *
-   * @param srid a int.
+   * @param srid an int.
    * @param strictParsing a boolean.
    * @param strictValidating a boolean.
    */
   public GML321GeotoolsParserImpl(final int srid, final boolean strictParsing,
       final boolean strictValidating) {
-    PARSER_THREAD_LOCAL =
-        ThreadLocal.withInitial(() -> buildParser(srid, strictParsing, strictValidating));
+    parserSupplier = () -> buildParser(srid, strictParsing, strictValidating);
     LOGGER.info("Create a parser for SRID: {}, strictParsing: {}, strictValidating: {}", srid,
         strictParsing, strictValidating);
   }
@@ -67,7 +67,7 @@ public class GML321GeotoolsParserImpl implements GMLParser {
   @Override
   public Geometry toJTSGeometry(Reader reader) throws GML3ParseException {
     try {
-      Object result = PARSER_THREAD_LOCAL.get().parse(reader);
+      Object result = parserSupplier.get().parse(reader);
       if (result instanceof Geometry geometry) {
         return geometry;
       } else {

--- a/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321ParserImpl.java
+++ b/src/main/java/nl/pdok/gml3/impl/gml3_2_1/GML321ParserImpl.java
@@ -3,7 +3,6 @@ package nl.pdok.gml3.impl.gml3_2_1;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 import java.io.Reader;
 import java.io.StringReader;
 import javax.xml.transform.stream.StreamSource;
@@ -32,23 +31,11 @@ public class GML321ParserImpl implements GMLParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GML321ParserImpl.class);
   private static final JAXBContext GML_321_JAXB_CONTEXT;
-  private static final ThreadLocal<Unmarshaller> GML_321_UNMARSHALLER;
 
   static {
     try {
       GML_321_JAXB_CONTEXT = JAXBContext.newInstance(AbstractGeometryType.class);
       LOGGER.debug("Created JAXB context");
-      GML_321_UNMARSHALLER = new ThreadLocal<>() {
-        @Override
-        protected Unmarshaller initialValue() {
-          try {
-            return GML_321_JAXB_CONTEXT.createUnmarshaller();
-          } catch (JAXBException ex) {
-            LOGGER.error(ex.getMessage(), ex);
-            throw new IllegalStateException(ex);
-          }
-        }
-      };
     } catch (JAXBException ex) {
       LOGGER.error("Could not create JAXB context. {}", ex.getMessage(), ex);
       throw new IllegalStateException("Could not create JAXB context", ex);
@@ -115,7 +102,7 @@ public class GML321ParserImpl implements GMLParser {
 
   private AbstractGeometryType parseGeometryFromGML(Reader reader) throws JAXBException {
     JAXBElement<AbstractGeometryType> unmarshalled =
-        (JAXBElement<AbstractGeometryType>) GML_321_UNMARSHALLER.get()
+        (JAXBElement<AbstractGeometryType>) GML_321_JAXB_CONTEXT.createUnmarshaller()
             .unmarshal(new StreamSource(reader));
     return unmarshalled.getValue();
   }


### PR DESCRIPTION
# Description

* Using `ThreadLocal` for caching has become an anti-pattern when using Java 21 Virtual Threads
* Some plugins and dependencies could be upgraded

## Type of change

- Minor change (typo, formatting, version bump)
- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR

Fixes https://github.com/PDOK/gml3-jts/issues/15